### PR TITLE
Close unclosed file

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,0 +1,2 @@
+tenets:
+  - import: codelingo/rfjakob-gocryptfs/missing-close-file

--- a/ssh.go
+++ b/ssh.go
@@ -21,6 +21,7 @@ func loadKey(keyPath string) ssh.AuthMethod {
 		log.InfoError(err)
 		return nil
 	}
+	defer f.Close()
 	data, _ := ioutil.ReadAll(f)
 	s, _ := ssh.ParsePrivateKey(data)
 	if s == nil {


### PR DESCRIPTION
Avoid resource leaks by closing files after they are used.

This issue was found using the [CodeLingo](https://www.codelingo.io) Tenet [missing-close-file](https://www.codelingo.io/tenets/codelingo/rfjakob-gocryptfs/missing-close-file) which I have added to a codelingo.yaml file at the root of the repo. This file is where you can import Tenets to run on future Pull Requests.